### PR TITLE
pass the raw IPN request from Paypal to PayPalIPN._postback to ensure go...

### DIFF
--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -14,9 +14,9 @@ class PayPalIPN(PayPalStandardBase):
         db_table = "paypal_ipn"
         verbose_name = "PayPal IPN"
 
-    def _postback(self):
+    def _postback(self, raw_ipn):
         """Perform PayPal Postback validation."""
-        return urlopen(self.get_endpoint(), "cmd=_notify-validate&%s" % self.query).read()
+        return urlopen(self.get_endpoint(), "cmd=_notify-validate&%s" % raw_ipn).read()
 
     def _verify_postback(self):
         if self.response != "VERIFIED":

--- a/paypal/standard/ipn/views.py
+++ b/paypal/standard/ipn/views.py
@@ -71,7 +71,8 @@ def ipn(request, item_check_callable=None):
         if request.is_secure() and 'secret' in request.GET:
             ipn_obj.verify_secret(form, request.GET['secret'])
         else:
-            ipn_obj.verify(item_check_callable)
+            raw_ipn = request.body
+            ipn_obj.verify(raw_ipn, item_check_callable)
 
     ipn_obj.save()
     return HttpResponse("OKAY")

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -252,7 +252,7 @@ class PayPalStandardBase(Model):
         if code is not None:
             self.flag_code = code
 
-    def verify(self, item_check_callable=None):
+    def verify(self, raw_ipn, item_check_callable=None):
         """
         Verifies an IPN and a PDT.
         Checks for obvious signs of weirdness in the payment and flags appropriately.
@@ -263,7 +263,7 @@ class PayPalStandardBase(Model):
         that `mc_gross`, `mc_currency` `item_name` and `item_number` are all correct.
 
         """
-        self.response = self._postback()
+        self.response = self._postback(raw_ipn)
         self._verify_postback()
         if not self.flag:
             if self.is_transaction():


### PR DESCRIPTION
...od validation (order of variables, see PP order management integration guide)

During my tests with IPN and postback validation, I received a lot of failed verifications. The reason was that Paypal did not received the arguments backs in the same order as it was sent.
I did not found anything that ensure this order in the django-paypal code (or did I miss it ?) and I did not understand why the postback request was build with _self.query_ instead of using the data Paypal just sent.
So here is what did to fix this problem, I hope there is no drawback I did not see :)

cheers,
Luc
