### PR TITLE
Added support for Django 1.5 custom user

### DIFF
--- a/paypal/pro/models.py
+++ b/paypal/pro/models.py
@@ -3,8 +3,14 @@
 from django.db import models
 from django.utils.http import urlencode
 from django.forms.models import model_to_dict
-from django.contrib.auth.models import User
 
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+    
 try:
     from idmapper.models import SharedMemoryModel as Model
 except ImportError:


### PR DESCRIPTION
This will avoid the error:

```
pro.paypalnvp: 'user' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
```

if the user decides to use a custom user model which is a feature for Django 1.5.
