### PR TITLE
Update for Django 1.5 custom user support

### DIFF
--- a/paypal/pro/models.py
+++ b/paypal/pro/models.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.db import models
 from django.utils.http import urlencode
 from django.forms.models import model_to_dict
-from django.contrib.auth.models import User
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 try:
     from idmapper.models import SharedMemoryModel as Model
@@ -66,7 +68,7 @@ class PayPalNVP(Model):
     custom = models.CharField(max_length=255, blank=True)
 
     # Admin fields
-    user = models.ForeignKey(User, blank=True, null=True)
+    user = models.ForeignKey(AUTH_USER_MODEL, blank=True, null=True)
     flag = models.BooleanField(default=False, blank=True)
     flag_code = models.CharField(max_length=32, blank=True)
     flag_info = models.TextField(blank=True)


### PR DESCRIPTION
If no `AUTH_USER_MODEL` in settings, use the default `auth.User` that points to default django contrib user model.
