### PR TITLE
Fix typo in the required fields of doExpressCheckoutPayment 

### DIFF
--- a/paypal/pro/helpers.py
+++ b/paypal/pro/helpers.py
@@ -120,7 +120,7 @@ class PayPalWPP(object):
         Check the dude out:
         """
         defaults = {"method": "DoExpressCheckoutPayment", "paymentaction": "Sale"}
-        required = ["returnurl", "cancelurl", "amt", "token payerid"]
+        required = ["returnurl", "cancelurl", "amt", "token", "payerid"]
         nvp_obj = self._fetch(params, required, defaults)
         if nvp_obj.flag:
             raise PayPalFailure(nvp_obj.flag_info)


### PR DESCRIPTION
It said 

```
required = ["returnurl", "cancelurl", "amt", "token payerid"]
```

instead of:

```
required = ["returnurl", "cancelurl", "amt", "token", "payerid"]
```
