### PR TITLE
Made PayPalPaymentsForm use the sandbox endpoint if PAYPAL_TEST is True

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Using PayPal Payments Standard IPN:
         INSTALLED_APPS = (... 'paypal.standard.ipn', ...)
         ...
         PAYPAL_RECEIVER_EMAIL = "yourpaypalemail@example.com"
+        
+        # For installations on which you want to use the sandbox,
+        # set PAYPAL_TEST to True.  Ensure PAYPAL_RECEIVER_EMAIL is set to
+        # your sandbox account email too.
+        # PAYPAL_TEST = True
 
 1. Create an instance of the `PayPalPaymentsForm` in the view where you would
    like to collect money. Call `render` on the instance in your template to

--- a/paypal/standard/forms.py
+++ b/paypal/standard/forms.py
@@ -6,6 +6,7 @@ from paypal.standard.conf import *
 from paypal.standard.widgets import ValueHiddenInput, ReservedValueHiddenInput
 from paypal.standard.conf import (POSTBACK_ENDPOINT, SANDBOX_POSTBACK_ENDPOINT,
                                   RECEIVER_EMAIL)
+from django.conf import settings
 
 
 # 20:18:05 Jan 30, 2009 PST - PST timezone support is not included out of the box.
@@ -106,18 +107,28 @@ class PayPalPaymentsForm(forms.Form):
                     self.fields[k] = forms.CharField(label=k, widget=ValueHiddenInput(), initial=v)
 
 
-    def render(self):
-        return mark_safe(u"""<form action="%s" method="post">
-    %s
-    <input type="image" src="%s" border="0" name="submit" alt="Buy it Now" />
-</form>""" % (POSTBACK_ENDPOINT, self.as_p(), self.get_image()))
+    def get_endpoint(self):
+        "Returns the endpoint url for the form."
+        if settings.PAYPAL_TEST:
+            return SANDBOX_POSTBACK_ENDPOINT
+        else:
+            return POSTBACK_ENDPOINT
 
 
-    def sandbox(self):
-        return mark_safe(u"""<form action="%s" method="post">
-    %s
-    <input type="image" src="%s" border="0" name="submit" alt="Buy it Now" />
-</form>""" % (SANDBOX_POSTBACK_ENDPOINT, self.as_p(), self.get_image()))
+     def render(self):
+         return mark_safe(u"""<form action="%s" method="post">
+     %s
+     <input type="image" src="%s" border="0" name="submit" alt="Buy it Now" />
+</form>""" % (self.get_endpoint(), self.as_p(), self.get_image()))
+ 
+ 
+     def sandbox(self):
+        "Deprecated.  Use self.render() instead."
+        import warnings
+        warnings.warn("""PaypalPaymentsForm.sandbox() is deprecated.
+                    Use the render() method instead.""", DeprecationWarning)
+        return self.render()
+
 
     def get_image(self):
         return {


### PR DESCRIPTION
Hi!  Here's the commit for the 'Better sandbox support' issue (https://github.com/spookylukey/django-paypal/issues/10).
