### PR TITLE
QueryDict is immutable. Create a copy before trying to change it.

### DIFF
--- a/paypal/standard/ipn/tests/test_ipn.py
+++ b/paypal/standard/ipn/tests/test_ipn.py
@@ -144,6 +144,16 @@ class IPNTest(TestCase):
 
         self.assertGotSignal(payment_was_refunded, False, params)
 
+    def test_with_na_date(self):
+        update = {
+            "payment_status": "Refunded",
+            "time_created": "N/A"
+        }
+        params = IPN_POST_PARAMS.copy()
+        params.update(update)
+
+        self.assertGotSignal(payment_was_refunded, False, params)
+
     def test_reversed_ipn(self):
         update = {
             "payment_status": "Reversed"

--- a/paypal/standard/ipn/views.py
+++ b/paypal/standard/ipn/views.py
@@ -35,7 +35,7 @@ def ipn(request, item_check_callable=None):
         data = None
     else:
         try:
-            data = QueryDict(request.body, encoding=encoding)
+            data = QueryDict(request.body, encoding=encoding).copy()
         except LookupError:
             data = None
             flag = "Invalid form - invalid charset"


### PR DESCRIPTION
This is a fix for issue #5
Test included
