### PR TITLE
Change signal sending to include nvp_obj as sender

### DIFF
--- a/paypal/pro/helpers.py
+++ b/paypal/pro/helpers.py
@@ -88,7 +88,7 @@ class PayPalWPP(object):
         nvp_obj = self._fetch(params, required, defaults)
         if nvp_obj.flag:
             raise PayPalFailure(nvp_obj.flag_info)
-        payment_was_successful.send(params)
+        payment_was_successful.send(sender=nvp_obj, **params)
         # @@@ Could check cvv2match / avscode are both 'X' or '0'
         # qd = django.http.QueryDict(nvp_obj.response)
         # if qd.get('cvv2match') not in ['X', '0']:
@@ -123,7 +123,7 @@ class PayPalWPP(object):
         nvp_obj = self._fetch(params, required, defaults)
         if nvp_obj.flag:
             raise PayPalFailure(nvp_obj.flag_info)
-        payment_was_successful.send(params)
+        payment_was_successful.send(sender=nvp_obj, **params)
         return nvp_obj
 
     def createRecurringPaymentsProfile(self, params, direct=False):
@@ -145,7 +145,7 @@ class PayPalWPP(object):
         # Flag if profile_type != ActiveProfile
         if nvp_obj.flag:
             raise PayPalFailure(nvp_obj.flag_info)
-        payment_profile_created.send(params)
+        payment_profile_created.send(sender=nvp_obj, **params)
         return nvp_obj
 
     def getExpressCheckoutDetails(self, params):


### PR DESCRIPTION
Since this [rather old Django commit](https://github.com/django/django/commit/704ee33f503c96b96c2682b946a11b3b42318ba7#diff-de999011ea114e4e4a35b1e412bfa0adR178) `Signal.send` looks for receivers in a cache. If we do not pass a sender explicitly, this method tries to find receivers using the first param as a dict key, raising `TypeError` (unhashable type).

Change the `send` call to include `nvp_obj` as sender and pass `params` as kwargs.
