### PR TITLE
Fixed #47 ImportError for urlopen

### DIFF
--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from six import b
-from six.moves.urllib.request import urlopen
+from django.utils.six.moves.urllib.request import urlopen
 
 from paypal.standard.models import PayPalStandardBase
 from paypal.standard.ipn.signals import *


### PR DESCRIPTION
Correcting the import of urlopen from six lib since urllib is available in django.utils.six module.
