### PR TITLE
Fix unicode errors on Py3

### DIFF
--- a/paypal/standard/helpers.py
+++ b/paypal/standard/helpers.py
@@ -3,11 +3,12 @@
 import hashlib
 
 from django.conf import settings
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
+from six import text_type
 
 
 def get_sha1_hexdigest(salt, raw_password):
-    return hashlib.sha1(smart_str(salt) + smart_str(raw_password)).hexdigest()
+    return hashlib.sha1(smart_bytes(salt) + smart_bytes(raw_password)).hexdigest()
 
 
 def duplicate_txn_id(ipn_obj):
@@ -49,13 +50,13 @@ def make_secret(form_instance, secret_fields=None):
     for name in secret_fields:
         if hasattr(form_instance, 'cleaned_data'):
             if name in form_instance.cleaned_data:
-                data += unicode(form_instance.cleaned_data[name])
+                data += text_type(form_instance.cleaned_data[name])
         else:
             # Initial data passed into the constructor overrides defaults.
             if name in form_instance.initial:
-                data += unicode(form_instance.initial[name])
+                data += text_type(form_instance.initial[name])
             elif name in form_instance.fields and form_instance.fields[name].initial is not None:
-                data += unicode(form_instance.fields[name].initial)
+                data += text_type(form_instance.fields[name].initial)
 
     secret = get_sha1_hexdigest(settings.SECRET_KEY, data)
     return secret


### PR DESCRIPTION
- Replace use of unicode with six.text_type
- Replace use of smart_str with smart_bytes
  - In Py2, hashlib implictly encodes unicode to ascii bytes, but Py3 is more strict and requires bytes.
