### PR TITLE
Add non-PayPal fields to exclude

### DIFF
--- a/paypal/standard/pdt/forms.py
+++ b/paypal/standard/pdt/forms.py
@@ -12,4 +12,4 @@ class PayPalPDTForm(PayPalStandardBaseForm):
     class Meta:
         model = PayPalPDT
         if django.VERSION >= (1, 6):
-            fields = '__all__'
+            exclude = ('ipaddress', 'flag', 'flag_code', 'flag_info', 'query', 'response', 'created_at', 'updated', 'form_view',)

--- a/paypal/standard/pdt/tests/test_pdt.py
+++ b/paypal/standard/pdt/tests/test_pdt.py
@@ -63,6 +63,9 @@ class PDTTest(TestCase):
         pdt_obj._verify_postback()
         self.assertEqual(len(PayPalPDT.objects.all()), 0)
         self.assertEqual(pdt_obj.txn_id, '1ED550410S3402306')
+        # Issue #121: Ensure for doesn't blank non-PayPal-supplied fields
+        self.assertEqual(pdt_obj.ipaddress, '127.0.0.1')
+        self.assertEqual(pdt_obj.response, paypal_response)
 
     def test_pdt(self):
         self.assertEqual(len(PayPalPDT.objects.all()), 0)


### PR DESCRIPTION
All the non-paypal fields are blanked if you don't exclude them from the form.