### PR TITLE
#77 remove required settings var PAYPAL_RECEIVER_EMAIL to allow different…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ detailed information about all changes.
 
 Below is a summary:
 
+Version 0.3.1
+-------------
+* Removed PAYPAL_RECEIVER_EMAIL from settings to allow multiple receiver emails
+  in a single app. Now validation of email must be done once received a
+  'valid tranasaction' signal.
+
 Version 0.3.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,8 @@ Version 0.3.0
 * Removed ``PAYPAL_RECEIVER_EMAIL`` from settings to allow multiple receiver emails
   in a single app. Now validation of email must be done once received a
   ``valid_ipn_received`` signal. Also when creating a ``PayPalPaymentsForm``
-  you must provide the ``business`` keyword parameter (because it no longer
-  defaults to ``PAYPAL_RECEIVER_EMAIL``.
+  you must provide the ``business`` field in the ``initial`` parameter
+  (because it no longer defaults to ``PAYPAL_RECEIVER_EMAIL``).
   *IMPORTANT*: checking the ``receiver_email`` on the ``valid_ipn_received``
   signal listener is very important to make sure that we are receiving
   the payment in the expected PayPal account. Take into account that the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,12 +9,6 @@ detailed information about all changes.
 
 Below is a summary:
 
-Version 0.3.1
--------------
-* Removed PAYPAL_RECEIVER_EMAIL from settings to allow multiple receiver emails
-  in a single app. Now validation of email must be done once received a
-  'valid tranasaction' signal.
-
 Version 0.3.0
 -------------
 
@@ -23,7 +17,17 @@ Version 0.3.0
 * Better logging for paypal.pro.
 * Fixed Django 1.7/1.8 compat for EmailField.
 * Added missing migration for PDT model.
-
+* Removed ``PAYPAL_RECEIVER_EMAIL`` from settings to allow multiple receiver emails
+  in a single app. Now validation of email must be done once received a
+  ``valid_ipn_received`` signal. Also when creating a ``PayPalPaymentsForm``
+  you must provide the ``business`` keyword parameter (because it no longer
+  defaults to ``PAYPAL_RECEIVER_EMAIL``.
+  *IMPORTANT*: checking the ``receiver_email`` on the ``valid_ipn_received``
+  signal listener is very important to make sure that we are receiving
+  the payment in the expected PayPal account. Take into account that the
+  user can tamper the form fields before posting them to PayPal.
+* The use of the ``pdt`` view for PDT payments is deprecated. Now you should
+  provide your own view and use the ``process_pdt`` helper function.
 
 Version 0.2.7
 -------------

--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -17,7 +17,7 @@ Using PayPal Standard IPN
 
 
    For installations on which you want to use the sandbox,
-   set PAYPAL_TEST to True.  
+   set PAYPAL_TEST to True.
 
    .. code-block:: python
        PAYPAL_TEST = True
@@ -27,9 +27,9 @@ Using PayPal Standard IPN
 2. :doc:`/updatedb`
 
 3. Create an instance of the ``PayPalPaymentsForm`` in the view where you would
-   like to collect money. 
-  
-   You must fill a dictionary with the information required to complete the 
+   like to collect money.
+
+   You must fill a dictionary with the information required to complete the
    payment, and pass it through the ``initial`` parameter when creating the
    ``PayPalPaymentsForm``.
 
@@ -98,7 +98,9 @@ Using PayPal Standard IPN
 
      This indicates a correct, non-duplicate IPN message from PayPal. The
      handler will receive a :class:`paypal.standard.ipn.models.PayPalIPN` object
-     as the sender. You will need to check the ``payment_status`` attribute and
+     as the sender. You will need to check the ``payment_status`` attribute,
+     and *specially the ``receiver_email``* to make sure that the account
+     receiving the payment is the expected one, as well as
      other attributes to know what action to take.
 
    * ``invalid_ipn_received``
@@ -127,6 +129,13 @@ Using PayPal Standard IPN
        def show_me_the_money(sender, **kwargs):
            ipn_obj = sender
            if ipn_obj.payment_status == ST_PP_COMPLETED:
+               # WARNING !
+               # Check that the receiver email is the same we previously
+               # set on the business field request. (The user could tamper
+               # with those fields on payment form before send it to PayPal)
+               if ipn_obj.receiver_email != "receiver_email@example.com":
+                   # Not a valid payment
+                   return
                # Undertake some action depending upon `ipn_obj`.
                if ipn_obj.custom == "Upgrade all users!":
                    Users.objects.update(paid=True)
@@ -145,7 +154,7 @@ Using PayPal Standard IPN
 
 6. You will also need to implement the ``return_url`` and ``cancel_return`` views
    to handle someone returning from PayPal.
-   
+
    Note that return_url view needs @csrf_exempt applied to it, because PayPal will POST to it, so it should be custom a view    that doesn't need to handle POSTs otherwise.
 
    When using PayPal Standard with Subscriptions this is not necessary since PayPal will route the user back to your site via    GET.

--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -1,8 +1,7 @@
 Using PayPal Standard IPN
 =========================
 
-1. Edit ``settings.py`` and add ``paypal.standard.ipn`` to your ``INSTALLED_APPS``
-   and ``PAYPAL_RECEIVER_EMAIL``:
+1. Edit ``settings.py`` and add ``paypal.standard.ipn`` to your ``INSTALLED_APPS``:
 
    settings.py:
 
@@ -16,17 +15,25 @@ Using PayPal Standard IPN
            #...
        ]
 
-       #...
-       PAYPAL_RECEIVER_EMAIL = "yourpaypalemail@example.com"
 
    For installations on which you want to use the sandbox,
-   set PAYPAL_TEST to True.  Ensure PAYPAL_RECEIVER_EMAIL is set to
-   your sandbox account email too.
+   set PAYPAL_TEST to True.  
+
+   .. code-block:: python
+       PAYPAL_TEST = True
+
+
 
 2. :doc:`/updatedb`
 
 3. Create an instance of the ``PayPalPaymentsForm`` in the view where you would
-   like to collect money. Call ``render`` on the instance in your template to
+   like to collect money. 
+  
+   You must fill a dictionary with the information required to complete the 
+   payment, and pass it through the ``initial`` parameter when creating the
+   ``PayPalPaymentsForm``.
+
+   Call ``render`` on the instance in your template to
    write out the HTML.
 
    views.py:
@@ -39,7 +46,7 @@ Using PayPal Standard IPN
 
            # What you want the button to do.
            paypal_dict = {
-               "business": settings.PAYPAL_RECEIVER_EMAIL,
+               "business": "receiver_email@example.com",
                "amount": "10000000.00",
                "item_name": "name of the item",
                "invoice": "unique-invoice-id",

--- a/docs/standard/pdt.rst
+++ b/docs/standard/pdt.rst
@@ -66,4 +66,10 @@ To use PDT:
         def your_pdt_return_url_view(request):
             pdt_obj, failed = process_pdt(request, item_check_callable=None)
             context = {"failed": failed, "pdt_obj": pdt_obj}
-            return render(request, 'my_template', context)
+            if not failed:
+                # IMPORTANT! :
+                # We should still check that the receiver_emails is the expected
+                if pdt_obj.receiver_email != 'my_account_email@example.com':
+                    # Do whatever action you expect         
+                    return render(request, 'my_valid_payment_template', context)
+            return render(request, 'my_non_valid_payment_template', context)

--- a/docs/standard/pdt.rst
+++ b/docs/standard/pdt.rst
@@ -31,20 +31,22 @@ To use PDT:
        PAYPAL_IDENTITY_TOKEN = "xxx"
 
    For installations on which you want to use the sandbox,
-   set PAYPAL_TEST to True.  Ensure PAYPAL_RECEIVER_EMAIL is set to
+   set PAYPAL_TEST to True.  While testing, ensure that when you create 
+   the PayPalPaymentsForm your receiver email (`business` parameter) is set to
    your sandbox account email too.
 
 2. :doc:`/updatedb`
 
-3. Create a view that uses `PayPalPaymentsForm` just like in :doc:`ipn`.
+3. Create a view that uses `PayPalPaymentsForm` just like in :doc:`ipn`. 
 
 4. After someone uses this button to buy something PayPal will return the user
    to your site at your ``return_url`` with some extra GET parameters.
 
-   The view ``paypal.standard.pdt.views.pdt`` handles PDT processing and renders
-   a simple template. It can be used as follows:
-
-
+   You will want to write a custom view that
+   calls ``paypal.standard.pdt.views.process_pdt``. This function returns
+   a tuple containing ``(PDT object, flag)``, where the ``flag`` is True
+   if verification failed.
+   
    Add the following to your `urls.py`:
 
    .. code-block:: python
@@ -52,16 +54,16 @@ To use PDT:
        from django.conf.urls import url, include
        ...
        urlpatterns = [
-           url(r'^paypal/pdt/', include('paypal.standard.pdt.urls')),
+           url(r'^your_return_url/', your_pdt_return_url_view, name="pdt_return_url"),
            ...
        ]
+  
 
-   Then specify the ``return_url`` to use this URL.
+    And then create a view that uses the `process_pdt` helper function: 
 
-   You will also need to have a ``base.html`` template with a block
-   ``content``. This template is inherited by the PDT view template.
-
-   More than likely, however, you will want to write a custom view that
-   calls ``paypal.standard.pdt.views.process_pdt``. This function returns
-   a tuple containing ``(PDT object, flag)``, where the ``flag`` is True
-   if verification failed.
+    .. code-block:: python  
+        @require_GET
+        def your_pdt_return_url_view(request):
+            pdt_obj, failed = process_pdt(request, item_check_callable=None)
+            context = {"failed": failed, "pdt_obj": pdt_obj}
+            return render(request, 'my_template', context)

--- a/docs/standard/subscriptions.rst
+++ b/docs/standard/subscriptions.rst
@@ -10,7 +10,7 @@ views.py:
 
     paypal_dict = {
        "cmd": "_xclick-subscriptions",
-       "business": settings.PAYPAL_RECEIVER_EMAIL,
+       "business": 'receiver_email@example.com',
        "a3": "9.99",                      # monthly price
        "p3": 1,                           # duration of each unit (depends on unit)
        "t3": "M",                         # duration unit ("M for Month")

--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,6 @@ settings.configure(
                {'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': 'test.db',
                 }},
-    PAYPAL_RECEIVER_EMAIL='',
     PAYPAL_IDENTITY_TOKEN='',
     INSTALLED_APPS=[
         'django.contrib.auth',

--- a/paypal/standard/conf.py
+++ b/paypal/standard/conf.py
@@ -5,9 +5,6 @@ class PayPalSettingsError(Exception):
     """Raised when settings be bad."""
 
 
-RECEIVER_EMAIL = settings.PAYPAL_RECEIVER_EMAIL
-
-
 # API Endpoints.
 POSTBACK_ENDPOINT = "https://www.paypal.com/cgi-bin/webscr"
 SANDBOX_POSTBACK_ENDPOINT = "https://www.sandbox.paypal.com/cgi-bin/webscr"

--- a/paypal/standard/forms.py
+++ b/paypal/standard/forms.py
@@ -73,7 +73,7 @@ class PayPalPaymentsForm(forms.Form):
     DONATE = 'donate'
 
     # Where the money goes.
-    business = forms.CharField(widget=ValueHiddenInput(), initial=settings.PAYPAL_RECEIVER_EMAIL)
+    business = forms.CharField(widget=ValueHiddenInput())
 
     # Item information.
     amount = forms.IntegerField(widget=ValueHiddenInput())

--- a/paypal/standard/ipn/tests/test_forms.py
+++ b/paypal/standard/ipn/tests/test_forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from paypal.standard.forms import PayPalPaymentsForm
 
@@ -22,3 +23,15 @@ class PaymentsFormTest(TestCase):
         with self.settings(PAYPAL_TEST=False):
             f = PayPalPaymentsForm(initial={})
             self.assertNotIn('sandbox', f.render())
+
+    @override_settings(PAYPAL_RECEIVER_EMAIL='me@mybusiness.com')
+    def test_form_render_deprecated_paypal_receiver_email(self):
+        f = PayPalPaymentsForm(initial={'amount': '10.50',
+                                        'shipping': '2.00',
+                                        })
+        rendered = f.render()
+        self.assertIn('''action="https://www.sandbox.paypal.com/cgi-bin/webscr"''', rendered)
+        self.assertIn('''value="me@mybusiness.com"''', rendered)
+        self.assertIn('''value="2.00"''', rendered)
+        self.assertIn('''value="10.50"''', rendered)
+        self.assertIn('''buynowCC''', rendered)

--- a/paypal/standard/ipn/tests/test_ipn.py
+++ b/paypal/standard/ipn/tests/test_ipn.py
@@ -209,6 +209,12 @@ class IPNTest(IPNTestBase):
 
         self.assertGotSignal(payment_was_reversed, False, params, deprecated=True)
 
+    @override_settings(PAYPAL_RECEIVER_EMAIL=TEST_RECEIVER_EMAIL)
+    def test_incorrect_receiver_email(self):
+        update = {"receiver_email": "incorrect_email@someotherbusiness.com"}
+        flag_info = "Invalid receiver_email. (incorrect_email@someotherbusiness.com)"
+        self.assertFlagged(update, flag_info)
+
     def test_invalid_payment_status(self):
         update = {"payment_status": "Failure"}
         flag_info = u"Invalid payment_status. (Failure)"

--- a/paypal/standard/ipn/tests/test_ipn.py
+++ b/paypal/standard/ipn/tests/test_ipn.py
@@ -22,12 +22,14 @@ from paypal.standard.ipn.signals import (payment_was_successful,
 # Parameters are all bytestrings, so we can construct a bytestring
 # request the same way that Paypal does.
 
+TEST_RECEIVER_EMAIL = b"seller@paypalsandbox.com"
+
 CHARSET = "windows-1252"
 IPN_POST_PARAMS = {
     "protection_eligibility": b"Ineligible",
     "last_name": b"User",
     "txn_id": b"51403485VH153354B",
-    "receiver_email": b(settings.PAYPAL_RECEIVER_EMAIL),
+    "receiver_email": TEST_RECEIVER_EMAIL,
     "payment_status": b"Completed",
     "payment_gross": b"10.00",
     "tax": b"0.00",
@@ -207,11 +209,6 @@ class IPNTest(IPNTestBase):
 
         self.assertGotSignal(payment_was_reversed, False, params, deprecated=True)
 
-    def test_incorrect_receiver_email(self):
-        update = {"receiver_email": "incorrect_email@someotherbusiness.com"}
-        flag_info = "Invalid receiver_email. (incorrect_email@someotherbusiness.com)"
-        self.assertFlagged(update, flag_info)
-
     def test_invalid_payment_status(self):
         update = {"payment_status": "Failure"}
         flag_info = u"Invalid payment_status. (Failure)"
@@ -381,8 +378,7 @@ class IPNPostbackTest(IPNTestBase):
         self.assertFlagged({}, u'Invalid postback. (INVALID)')
 
 
-@override_settings(ROOT_URLCONF='paypal.standard.ipn.tests.test_urls',
-                   PAYPAL_RECEIVER_EMAIL='seller@paypalsandbox.com')
+@override_settings(ROOT_URLCONF='paypal.standard.ipn.tests.test_urls')
 class IPNSimulatorTests(TestCase):
 
     # Some requests, as sent by the simulator.

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from warnings import warn
+
 from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
@@ -327,8 +329,13 @@ class PayPalStandardBase(Model):
                     self.set_flag("Invalid payment_status. (%s)" % self.payment_status)
                 if duplicate_txn_id(self):
                     self.set_flag("Duplicate txn_id. (%s)" % self.txn_id)
-                if self.receiver_email != settings.PAYPAL_RECEIVER_EMAIL:
-                    self.set_flag("Invalid receiver_email. (%s)" % self.receiver_email)
+                if hasattr(settings, 'PAYPAL_RECEIVER_EMAIL'):
+                    warn("""Use of PAYPAL_RECEIVER_EMAIL in settings has been Deprecated. 
+                            Check of valid email must be done when receiving the 
+                            valid_ipn_received / valid_pdt_received signal""",
+                          DeprecationWarning)
+                    if self.receiver_email != settings.PAYPAL_RECEIVER_EMAIL:
+                        self.set_flag("Invalid receiver_email. (%s)" % self.receiver_email)
                 if callable(item_check_callable):
                     flag, reason = item_check_callable(self)
                     if flag:

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -332,7 +332,7 @@ class PayPalStandardBase(Model):
                 if hasattr(settings, 'PAYPAL_RECEIVER_EMAIL'):
                     warn("""Use of PAYPAL_RECEIVER_EMAIL in settings has been Deprecated. 
                             Check of valid email must be done when receiving the 
-                            valid_ipn_received / valid_pdt_received signal""",
+                            valid_ipn_received signal""",
                           DeprecationWarning)
                     if self.receiver_email != settings.PAYPAL_RECEIVER_EMAIL:
                         self.set_flag("Invalid receiver_email. (%s)" % self.receiver_email)

--- a/paypal/standard/pdt/tests/test_pdt.py
+++ b/paypal/standard/pdt/tests/test_pdt.py
@@ -18,7 +18,7 @@ class DummyPayPalPDT(object):
     def __init__(self, update_context_dict={}):
         self.context_dict = {'st': 'SUCCESS', 'custom': 'cb736658-3aad-4694-956f-d0aeade80194',
                              'txn_id': '1ED550410S3402306', 'mc_gross': '225.00',
-                             'business': settings.PAYPAL_RECEIVER_EMAIL, 'error': 'Error code: 1234'}
+                             'business': 'test@example.com', 'error': 'Error code: 1234'}
 
         self.context_dict.update(update_context_dict)
         self.response = ''

--- a/paypal/standard/pdt/views.py
+++ b/paypal/standard/pdt/views.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from warnings import warn
 
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
@@ -13,6 +14,9 @@ def pdt(request, item_check_callable=None, template="pdt/pdt.html", context=None
     """Standard implementation of a view that processes PDT and then renders a template
     For more advanced uses, create your own view and call process_pdt.
     """
+    warn("""Use of pdt view is deprecated. Instead you should create your
+            own view, and use the process_pdt helper function""",
+            DeprecationWarning)
     pdt_obj, failed = process_pdt(request, item_check_callable)
 
     context = context or {}

--- a/runtests.py
+++ b/runtests.py
@@ -13,7 +13,6 @@ warnings.simplefilter("always", DeprecationWarning)
 settings.configure(
     ROOT_URLCONF='',
     DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'}},
-    PAYPAL_RECEIVER_EMAIL='test@example.com',
     PAYPAL_TEST=True,
     # Please dont make me create another test account and remove this from here :)
     PAYPAL_WPP_USER='dcrame_1278645792_biz_api1.gmail.com',


### PR DESCRIPTION
Remove required settings var __PAYPAL_RECEIVER_EMAIL__ to allow different receiver emails. 
It only affects standard payments (IPN and PDT). 
Checks if the *settings.PAYPAL_RECEIVER_EMAIL* exists in settings when validating the received payment information, and in that case it issues a DeprecationWarning and has the previous behaviour (however, __*settings.PAYPAL_RECEIVER_EMAIL* is not used as default value__ for the *business* field in the **PayPalPaymentsForm**, and should be set when creating a **PayPalPaymentsForm** instance). If it does not exists it does not perfomer the email check.

Changed the docs, and removed the test that checks for invalid email flag.