### PR TITLE
Raise HTTPError for issues with the validation postback

### DIFF
--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -23,7 +23,9 @@ class PayPalIPN(PayPalStandardBase):
 
     def _postback(self):
         """Perform PayPal Postback validation."""
-        return requests.post(self.get_endpoint(), data=b("cmd=_notify-validate&%s" % self.query)).content
+        r = requests.post(self.get_endpoint(), data=b("cmd=_notify-validate&%s" % self.query))
+        r.raise_for_status()
+        return r.content
 
     def _verify_postback(self):
         if self.response != "VERIFIED":


### PR DESCRIPTION
The aim for this PR is to not return a 200 to PayPal, when the postback validation fails.
By not returning a 200, PayPal would resend the IPN and allows the receiver to process the IPN again automatically.

This would change how django-paypal treats `Internal Server Error` that PayPal responds with.
I'm curious to hear your opinion on this direction.
