### PR TITLE
Added get_endpoint to form example.

### DIFF
--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -75,7 +75,9 @@ Using PayPal Standard IPN
        ...
        <h1>Show me the money!</h1>
        <!-- writes out the form tag automatically -->
-       {{ form.render }}
+       <form method="post" action="{{ form.get_endpoint }}">
+         {{ form.render }}
+       </form>
 
 
 4. When someone uses this button to buy something PayPal makes a HTTP POST to


### PR DESCRIPTION
Added PayPal form example, with action set to `form.get_endpoint()` value.