### PR TITLE
Update docs regarding checking 'receiver_email

### DIFF
--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -105,7 +105,7 @@ Using PayPal Standard IPN
      This indicates a correct, non-duplicate IPN message from PayPal. The
      handler will receive a :class:`paypal.standard.ipn.models.PayPalIPN` object
      as the sender. You will need to check the ``payment_status`` attribute, and
-     the ``receiver_email`` to make sure that the account receiving the payment
+     the ``business`` to make sure that the account receiving the payment
      is the expected one, as well as other attributes to know what action to
      take.
 


### PR DESCRIPTION
The docs state 

> You will need to check the `payment_status` attribute, and the `receiver_email` to make sure that the account receiving the payment is the expected one, as well as other attributes to know what action to take.

`receiver_email` is actually the receipient's primary email on their PayPal account - which is usually, but *not always* the same as `business`.  `business` is the email address that the payment goes to, and is the one that needs to be checked. 

(I was just bitten by this when setting up a new site where the receiver had changed their email recently, so business/receiver_email were different.  I was checking that `receiver_email` was the same as the email address I put into the paypal_dict as `business` and failing my own check.