### PR TITLE
Added more methods for subscription specific IPNs

### DIFF
--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -276,6 +276,12 @@ class PayPalStandardBase(Model):
     def is_subscription(self):
         return len(self.subscr_id) > 0
 
+    def is_subscription_payment(self):
+        return self.txn_type == "subscr_payment"
+
+    def is_subscription_failed(self):
+        return self.txn_type == "subscr_failed"
+
     def is_subscription_cancellation(self):
         return self.txn_type == "subscr_cancel"
 


### PR DESCRIPTION
Added two more methods for subscription specific IPN `is_subscription_payment` and `is_subscription_failed` as described in PayPal docs: 
https://www.paypal.com/us/cgi-bin/webscr?cmd=p/acc/ipn-subscriptions-outside