### PR TITLE
Added lazy translation to pro app's form's labels

### DIFF
--- a/paypal/pro/forms.py
+++ b/paypal/pro/forms.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from paypal.pro.exceptions import PayPalFailure
 from paypal.pro.fields import CountryField, CreditCardCVV2Field, CreditCardExpiryField, CreditCardField
@@ -11,17 +12,17 @@ from paypal.utils import warn_untested
 
 class PaymentForm(forms.Form):
     """Form used to process direct payments."""
-    firstname = forms.CharField(255, label="First Name")
-    lastname = forms.CharField(255, label="Last Name")
-    street = forms.CharField(255, label="Street Address")
-    city = forms.CharField(255, label="City")
-    state = forms.CharField(255, label="State")
-    countrycode = CountryField(label="Country", initial="US")
-    zip = forms.CharField(32, label="Postal / Zip Code")
-    acct = CreditCardField(label="Credit Card Number")
-    expdate = CreditCardExpiryField(label="Expiration Date")
-    cvv2 = CreditCardCVV2Field(label="Card Security Code")
-    currencycode = forms.CharField(widget=forms.HiddenInput(), initial="USD")
+    firstname = forms.CharField(255, label=_("First Name"))
+    lastname = forms.CharField(255, label=_("Last Name"))
+    street = forms.CharField(255, label=_("Street Address"))
+    city = forms.CharField(255, label=_("City"))
+    state = forms.CharField(255, label=_("State"))
+    countrycode = CountryField(label=_("Country", initial="US"))
+    zip = forms.CharField(32, label=_("Postal / Zip Code"))
+    acct = CreditCardField(label=_("Credit Card Number"))
+    expdate = CreditCardExpiryField(label=_("Expiration Date"))
+    cvv2 = CreditCardCVV2Field(label=_("Card Security Code"))
+    currencycode = forms.CharField(widget=forms.HiddenInput(), initial="USD"))
 
     def process(self, request, item):
         """Process a PayPal direct payment."""

--- a/paypal/pro/forms.py
+++ b/paypal/pro/forms.py
@@ -17,7 +17,7 @@ class PaymentForm(forms.Form):
     street = forms.CharField(255, label=_("Street Address"))
     city = forms.CharField(255, label=_("City"))
     state = forms.CharField(255, label=_("State"))
-    countrycode = CountryField(label=_("Country", initial="US"))
+    countrycode = CountryField(label=_("Country"), initial="US")
     zip = forms.CharField(32, label=_("Postal / Zip Code"))
     acct = CreditCardField(label=_("Credit Card Number"))
     expdate = CreditCardExpiryField(label=_("Expiration Date"))

--- a/paypal/pro/forms.py
+++ b/paypal/pro/forms.py
@@ -22,7 +22,7 @@ class PaymentForm(forms.Form):
     acct = CreditCardField(label=_("Credit Card Number"))
     expdate = CreditCardExpiryField(label=_("Expiration Date"))
     cvv2 = CreditCardCVV2Field(label=_("Card Security Code"))
-    currencycode = forms.CharField(widget=forms.HiddenInput(), initial="USD"))
+    currencycode = forms.CharField(widget=forms.HiddenInput(), initial="USD")
 
     def process(self, request, item):
         """Process a PayPal direct payment."""


### PR DESCRIPTION
Slight update for the PaymentForm to implement lazy translation of form's labels, as asked on #181.