### PR TITLE
Fix PayPalSharedSecretEncryptedPaymentsForm in Python 3

### DIFF
--- a/paypal/standard/helpers.py
+++ b/paypal/standard/helpers.py
@@ -7,10 +7,12 @@ from django.utils.encoding import smart_str
 
 from paypal.utils import warn_untested
 
+import six
 
 def get_sha1_hexdigest(salt, raw_password):
     warn_untested()
-    return hashlib.sha1(smart_str(salt) + smart_str(raw_password)).hexdigest()
+    encoded_string = (smart_str(salt) + smart_str(raw_password)).encode('utf-8')
+    return hashlib.sha1(encoded_string).hexdigest()
 
 
 def duplicate_txn_id(ipn_obj):
@@ -57,13 +59,13 @@ def make_secret(form_instance, secret_fields=None):
     for name in secret_fields:
         if hasattr(form_instance, 'cleaned_data'):
             if name in form_instance.cleaned_data:
-                data += unicode(form_instance.cleaned_data[name])
+                data += six.text_type(form_instance.cleaned_data[name])
         else:
             # Initial data passed into the constructor overrides defaults.
             if name in form_instance.initial:
-                data += unicode(form_instance.initial[name])
+                data += six.text_type(form_instance.initial[name])
             elif name in form_instance.fields and form_instance.fields[name].initial is not None:
-                data += unicode(form_instance.fields[name].initial)
+                data += six.text_type(form_instance.fields[name].initial)
 
     secret = get_sha1_hexdigest(settings.SECRET_KEY, data)
     return secret

--- a/runtests.py
+++ b/runtests.py
@@ -35,6 +35,7 @@ settings_dict = dict(
         'django.contrib.admin',
         'django.contrib.sessions',
         'django.contrib.contenttypes',
+        'django.contrib.messages',
         'paypal.pro',
         'paypal.standard',
         'paypal.standard.ipn',


### PR DESCRIPTION
Building off the work in #217 and #211... I simply swapped to using six (already a requirement in the package) and made a minor to change support Python's .encode() function per comments in previous PRs. Reused tests from previous PR.

Tests pass however PayPal's sandbox IPN is currently down:
https://www.paypal-community.com/t5/Sandbox-Environment/IPN-not-working-Sandbox/m-p/2030902/highlight/true#M5746

What are your thoughts on this @spookylukey? I can update once PayPal has fixed their sandbox to confirm functionality.