### PR TITLE
docs: Fix simple typo, similiar -> similar

### DIFF
--- a/paypal/standard/pdt/admin.py
+++ b/paypal/standard/pdt/admin.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from paypal.standard.pdt.models import PayPalPDT
 
 
-# ToDo: How similiar is this to PayPalIPNAdmin? Could we just inherit off one common admin model?
+# ToDo: How similar is this to PayPalIPNAdmin? Could we just inherit off one common admin model?
 class PayPalPDTAdmin(admin.ModelAdmin):
     date_hierarchy = 'payment_date'
     fieldsets = (


### PR DESCRIPTION
There is a small typo in paypal/standard/pdt/admin.py.

Should read `similar` rather than `similiar`.

