### PR TITLE
Fix PayPalSharedSecretEncryptedPaymentsForm in Python 3

### DIFF
--- a/paypal/standard/helpers.py
+++ b/paypal/standard/helpers.py
@@ -7,10 +7,12 @@ from django.utils.encoding import smart_str
 
 from paypal.utils import warn_untested
 
+import six
+
 
 def get_sha1_hexdigest(salt, raw_password):
-    warn_untested()
-    return hashlib.sha1(smart_str(salt) + smart_str(raw_password)).hexdigest()
+    encoded_string = (smart_str(salt) + smart_str(raw_password)).encode('utf-8')
+    return hashlib.sha1(encoded_string).hexdigest()
 
 
 def duplicate_txn_id(ipn_obj):
@@ -57,13 +59,13 @@ def make_secret(form_instance, secret_fields=None):
     for name in secret_fields:
         if hasattr(form_instance, 'cleaned_data'):
             if name in form_instance.cleaned_data:
-                data += unicode(form_instance.cleaned_data[name])
+                data += six.text_type(form_instance.cleaned_data[name])
         else:
             # Initial data passed into the constructor overrides defaults.
             if name in form_instance.initial:
-                data += unicode(form_instance.initial[name])
+                data += six.text_type(form_instance.initial[name])
             elif name in form_instance.fields and form_instance.fields[name].initial is not None:
-                data += unicode(form_instance.fields[name].initial)
+                data += six.text_type(form_instance.fields[name].initial)
 
     secret = get_sha1_hexdigest(settings.SECRET_KEY, data)
     return secret

--- a/paypal/standard/ipn/tests/test_forms.py
+++ b/paypal/standard/ipn/tests/test_forms.py
@@ -5,7 +5,11 @@ import re
 
 from django.test import TestCase
 
-from paypal.standard.forms import PayPalEncryptedPaymentsForm, PayPalPaymentsForm
+from paypal.standard.forms import (
+    PayPalEncryptedPaymentsForm,
+    PayPalPaymentsForm,
+    PayPalSharedSecretEncryptedPaymentsForm
+)
 from paypal.standard.ipn.forms import PayPalIPNForm
 
 
@@ -87,7 +91,42 @@ class PaymentsFormTest(TestCase):
             paypal_cert=paypal_cert,
             cert_id=paypal_cert_id
         )
+        rendered = form.render()
 
+        self.assertIn('''name="cmd" value="_s-xclick"''', rendered)
+        self.assertIn('''name="encrypted" value="-----BEGIN PKCS7-----''', rendered)
+        expected_regex = re.compile(
+            r'.*name="encrypted" value="-----BEGIN PKCS7-----\n' +
+            r'([A-Za-z0-9/\+]{64}\n)*[A-Za-z0-9/\+]{1,64}={0,2}\n' +
+            r'-----END PKCS7-----\n.*'
+        )
+        self.assertTrue(
+            expected_regex.search(rendered),
+            msg='Button encryption has wrong form - expected a block of PKCS7 data'
+        )
+
+    def test_shared_secret_encrypted_button(self):
+        data = {
+            'notify_url': 'https://example.com/notify_url',
+            'amount': '10.50',
+            'shipping': '2.00',
+        }
+
+        # Paypal Certificate Information
+        here = os.path.dirname(os.path.abspath(__file__))
+        paypal_private_cert = os.path.join(here, 'test_cert__do_not_use__private.pem')
+        paypal_public_cert = os.path.join(here, 'test_cert__do_not_use__public.pem')
+        paypal_cert = os.path.join(here, 'test_cert_from_paypal__do_not_use.pem')
+        paypal_cert_id = 'another-paypal-id'
+
+        # Create the instance.
+        form = PayPalSharedSecretEncryptedPaymentsForm(
+            initial=data,
+            private_cert=paypal_private_cert,
+            public_cert=paypal_public_cert,
+            paypal_cert=paypal_cert,
+            cert_id=paypal_cert_id
+        )
         rendered = form.render()
 
         self.assertIn('''name="cmd" value="_s-xclick"''', rendered)


### PR DESCRIPTION
Based on PRs #223 #217 #211

Addressed all comments and cleaned up flake8 errors.