### PR TITLE
Fix broken PayPal links in docs

### DIFF
--- a/docs/standard/subscriptions.rst
+++ b/docs/standard/subscriptions.rst
@@ -31,4 +31,4 @@ views.py:
 
 
 See `PayPal Subscribe button docs
-<https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/subscribe_buttons/>`_.
+<https://developer.paypal.com/docs/paypal-payments-standard/integration-guide/subscribe-step-1/>`_.

--- a/docs/standard/variables.rst
+++ b/docs/standard/variables.rst
@@ -4,7 +4,7 @@ IPN/PDT variables
 
 The data variables that are returned on the IPN object are documented here:
 
-https://developer.paypal.com/webapps/developer/docs/classic/ipn/integration-guide/IPNandPDTVariables/
+https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNandPDTVariables/
 
 .. note:: The names of these data variables are not the same as the values that
           you `pass to PayPal
@@ -22,5 +22,5 @@ which returns a dictionary of all data sent by PayPal.
 
 When processing these objects for handling payments, you need to pay particular
 attention to ``payment_status`` (`docs
-<https://developer.paypal.com/webapps/developer/docs/classic/ipn/integration-guide/IPNandPDTVariables/#id091EB04C0HS__id0913D0E0UQU>`_).
+<https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNandPDTVariables/#payment-information-variables>`_).
 You can use the ``ST_PP_*`` constants in ``paypal.standard.models`` to help.


### PR DESCRIPTION
Fixes #228, along with a couple of other links.