### PR TITLE
Remove out-of-date import from example code

### DIFF
--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -92,7 +92,14 @@ Using PayPal Standard IPN
    correct ``notify_url`` add the following to your ``urls.py``:
 
    .. code-block:: python
+       # Django 2.0+
+       from django.urls import path, include
 
+       urlpatterns = [
+           path("paypal/", include("paypal.standard.ipn.urls")),
+       ]
+
+       # Django 1.11
        from django.conf.urls import url, include
 
        urlpatterns = [

--- a/docs/standard/ipn.rst
+++ b/docs/standard/ipn.rst
@@ -43,8 +43,7 @@ Using PayPal Standard IPN
    ``views.py``:
 
    .. code-block:: python
-
-       from django.core.urlresolvers import reverse
+       from django.urls import reverse
        from django.shortcuts import render
        from paypal.standard.forms import PayPalPaymentsForm
 


### PR DESCRIPTION
# Description

This PR lightly updates the documentation. Changes include:

* change an import in the example code, since Django deprecated `django.core.urlresolvers` in release 1.10: sincehttps://docs.djangoproject.com/en/1.10/releases/1.10/
* extend the example for setting up 'notify_url' 

