### PR TITLE
Fix Django versions in Actions and extend to Django 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
         - python-version: 3.9
           django-version: 3.1.7
           usetz: true
+        - python-version: 3.9
+          django-version: 3.2.9
+          usetz: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install Django==${{ matrix.django-version }}
         pip install -e .
         pip install -r requirements-test.txt
     - name: Test suite

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
         py39-django22-tests-usetztrue,
         py39-django30-tests-usetztrue,
         py39-django31-tests-usetztrue,
+        py39-django32-tests-usetztrue,
         checkmanifest, isort-check, flake8-check
 
 [testenv]
@@ -35,6 +36,7 @@ deps =
      django22: Django==2.2.19
      django30: Django==3.0.13
      django31: Django==3.1.7
+     django32: Django==3.2.9
      usetztrue: pytz
 
 [testenv:checkmanifest]


### PR DESCRIPTION
The workflow is not installing the Django version specified by `matrix.django-version`, so all tests are being run with `Django>=1.11` as specified in django-paypal's dependencies.

This PR installs the correct version and extends the matrix to cover Django 3.2.