### PR TITLE
Fix intermittent PDT issues

### DIFF
--- a/paypal/standard/pdt/forms.py
+++ b/paypal/standard/pdt/forms.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django import forms
+
 from paypal.standard.forms import PayPalStandardBaseForm
 from paypal.standard.pdt.models import PayPalPDT
 
@@ -12,3 +14,9 @@ class PayPalPDTForm(PayPalStandardBaseForm):
         exclude = ['ipaddress', 'flag', 'flag_code',
                    'flag_info', 'query', 'response',
                    'created_at', 'updated', 'form_view']
+
+
+class PayPalPDTCallbackForm(forms.ModelForm):
+    class Meta:
+        model = PayPalPDT
+        fields = ['amt', 'cm', 'tx', 'st']

--- a/paypal/standard/pdt/tests/test_pdt.py
+++ b/paypal/standard/pdt/tests/test_pdt.py
@@ -107,6 +107,45 @@ class PDTTest(TestCase):
         pdt_obj = PayPalPDT.objects.all()[0]
         self.assertEqual(pdt_obj.custom, self.get_params['cm'])
 
+    def test_pdt_full_params(self):
+        # New callback parameters as of May 2021
+        self.assertEqual(len(PayPalPDT.objects.all()), 0)
+        params = {
+            "PayerID": "8MZ9FQTSAMUPJ",
+            "st": "Completed",
+            "tx": "4WJ86550014687441",
+            "cc": "EUR",
+            "amt": "225.00",
+            "cm": "a3e192b8-8fea-4a86-b2e8-d5bf502e36be",
+            "payer_email": "buyer_1239119200_per%40yoursite.com",
+            "payer_id": "8MZ9FQTSAMUPJ",
+            "payer_status": "VERIFIED",
+            "first_name": "Test",
+            "last_name": "User",
+            "txn_id": "1ED550410S3402306",
+            "mc_currency": "EUR",
+            "mc_fee": "6.88",
+            "mc_gross": "225.00",
+            "protection_eligibility": "Ineligible",
+            "payment_fee": "6.88",
+            "payment_gross": "5.00",
+            "payment_status": "Completed",
+            "payment_type": "instant",
+            "handling_amount": "0.00",
+            "shipping": "0.00",
+            "item_name": "Example",
+            "quantity": "1",
+            "txn_type": "web_accept",
+            "payment_date": "2021-11-05T10:23:28Z",
+            "business": "test@example.com",
+            "receiver_id": "746LDC2EQAP4W",
+            "notify_version": "UNVERSIONED",
+            "custom": "ABC123",
+            "verify_sign": "ABC123",
+        }
+        paypal_response = self.client.get("/pdt/", params)
+        self.assertContains(paypal_response, 'Transaction complete', status_code=200)
+        self.assertEqual(len(PayPalPDT.objects.all()), 1)
 
 class MockedResponse:
     content = 'test'

--- a/paypal/standard/pdt/tests/test_pdt.py
+++ b/paypal/standard/pdt/tests/test_pdt.py
@@ -147,6 +147,7 @@ class PDTTest(TestCase):
         self.assertContains(paypal_response, 'Transaction complete', status_code=200)
         self.assertEqual(len(PayPalPDT.objects.all()), 1)
 
+
 class MockedResponse:
     content = 'test'
 

--- a/paypal/standard/pdt/views.py
+++ b/paypal/standard/pdt/views.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from paypal.standard.pdt.forms import PayPalPDTForm
+from paypal.standard.pdt.forms import PayPalPDTCallbackForm
 from paypal.standard.pdt.models import PayPalPDT
 from paypal.utils import warn_untested
 
@@ -32,7 +32,7 @@ def process_pdt(request):
             pass
 
         if pdt_obj is None:
-            form = PayPalPDTForm(request.GET)
+            form = PayPalPDTCallbackForm(request.GET)
             if form.is_valid():
                 try:
                     pdt_obj = form.save(commit=False)


### PR DESCRIPTION
Fixes issue #239.

Rather than use the same form for both the PDT callback and the postback, split these apart. We'll take a minimal set of parameters from the callback, and fill in rest using the postback endpoint.

I've included a test which includes the full set of query parameters I'm seeing on most (but not all) PDT callback requests. Note `payment_date` is in ISO format in these requests, and `notify_version` is a string. With this PR both these parameters will be ignored. 

