### PR TITLE
django 4 compatibility: changing deprecated force_text to force_str

### DIFF
--- a/paypal/standard/widgets.py
+++ b/paypal/standard/widgets.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.forms.utils import flatatt
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 
 
@@ -36,5 +36,5 @@ class ReservedValueHiddenInput(ValueHiddenInput):
         final_attrs['type'] = self.input_type
         final_attrs.update(attrs)
         if value != '':
-            final_attrs['value'] = force_text(value)
+            final_attrs['value'] = force_str(value)
         return mark_safe(u'<input%s />' % flatatt(final_attrs))


### PR DESCRIPTION
django-paypal gives a compilation error with Django 4 because of the deprecated `force_text`