### PR TITLE
bug fix, although I cannot tell how this ever worked, so really I jus…

### DIFF
--- a/paypal/pro/fields.py
+++ b/paypal/pro/fields.py
@@ -4,6 +4,7 @@ from calendar import monthrange
 from datetime import date
 
 from django import forms
+from django.core.validators import EMPTY_VALUES
 from django.utils.translation import gettext_lazy as _
 
 from paypal.pro.creditcard import verify_credit_card
@@ -83,10 +84,10 @@ class CreditCardExpiryField(forms.MultiValueField):
     def compress(self, data_list):
         warn_untested()
         if data_list:
-            if data_list[1] in forms.fields.EMPTY_VALUES:
+            if data_list[1] in EMPTY_VALUES:
                 error = self.error_messages["invalid_year"]
                 raise forms.ValidationError(error)
-            if data_list[0] in forms.fields.EMPTY_VALUES:
+            if data_list[0] in EMPTY_VALUES:
                 error = self.error_messages["invalid_month"]
                 raise forms.ValidationError(error)
             year = int(data_list[1])


### PR DESCRIPTION
…t want to start the discussion.

As far as I can tell, forms.fields has never had a member call EMPTY_VALUES. There is empty_values, and there is django.core.validators.EMPTY_VALUES. So how did this code ever work? 
